### PR TITLE
Add service rating-based tip selection for predefined percentages

### DIFF
--- a/app/src/main/java/com/example/tiptime/MainActivity.kt
+++ b/app/src/main/java/com/example/tiptime/MainActivity.kt
@@ -69,9 +69,11 @@ class MainActivity : AppCompatActivity() {
         }
 
         // Get the tip percentage based on which radio button is selected
-        val tipPercentage = when (binding.tipOptions.checkedRadioButtonId) {
-            R.id.option_twenty_percent -> 0.20
-            R.id.option_eighteen_percent -> 0.18
+       val tipPercentage = when (binding.tipOptions.checkedRadioButtonId) {
+            R.id.option_poor_service -> 0.10
+            R.id.option_average_service -> 0.15
+            R.id.option_good_service -> 0.18
+            R.id.option_excellent_service -> 0.20
             else -> 0.15
         }
 

--- a/app/src/main/java/com/example/tiptime/MainActivity.kt
+++ b/app/src/main/java/com/example/tiptime/MainActivity.kt
@@ -64,12 +64,12 @@ class MainActivity : AppCompatActivity() {
 
         // If the cost is null or 0, then display 0 tip and exit this function early.
         if (cost == null || cost == 0.0) {
-            displayTip(0.0)
+            displayTipAndTotal(0.0, 0.0)
             return
         }
 
-        // Get the tip percentage based on which radio button is selected
-       val tipPercentage = when (binding.tipOptions.checkedRadioButtonId) {
+        // Get the tip percentage based on service quality selected
+        val tipPercentage = when (binding.tipOptions.checkedRadioButtonId) {
             R.id.option_poor_service -> 0.10
             R.id.option_average_service -> 0.15
             R.id.option_good_service -> 0.18
@@ -79,27 +79,47 @@ class MainActivity : AppCompatActivity() {
 
         // Calculate the tip
         var tip = tipPercentage * cost
+        var totalBill = cost + tip
 
-        // If the switch for rounding up the tip toggled on (isChecked is true), then round up the
-        // tip. Otherwise do not change the tip value.
-        val roundUp = binding.roundUpSwitch.isChecked
-        if (roundUp) {
-            // Take the ceiling of the current tip, which rounds up to the next integer, and store
-            // the new value in the tip variable.
-            tip = kotlin.math.ceil(tip)
+//        // If the switch for rounding up the tip toggled on (isChecked is true), then round up the
+//        // tip. Otherwise do not change the tip value.
+//        val roundUp = binding.roundUpSwitch.isChecked
+//        if (roundUp) {
+//            // Take the ceiling of the current tip, which rounds up to the next integer, and store
+//            // the new value in the tip variable.
+//            tip = kotlin.math.ceil(tip)
+//        }
+
+        // Handle the two switches: Round Tip and Round Total Bill
+        when {
+            binding.roundUpSwitch.isChecked -> {
+                // Round the tip up if the "Round Tip" switch is enabled
+                tip = kotlin.math.ceil(tip)
+                totalBill = cost + tip
+                binding.roundTotalSwitch.isChecked = false // Uncheck the other switch
+            }
+            binding.roundTotalSwitch.isChecked -> {
+                // Round the total bill to the nearest whole number if the "Round Total Bill" switch is enabled
+                totalBill = kotlin.math.ceil(totalBill)
+                binding.roundUpSwitch.isChecked = false // Uncheck the other switch
+            }
         }
 
         // Display the formatted tip value onscreen
-        displayTip(tip)
+        displayTipAndTotal(tip, totalBill)
     }
 
     /**
      * Format the tip amount according to the local currency and display it onscreen.
      * Example would be "Tip Amount: $10.00".
      */
-    private fun displayTip(tip: Double) {
+    private fun displayTipAndTotal(tip: Double, totalBill: Double) {
         val formattedTip = NumberFormat.getCurrencyInstance().format(tip)
+        val formattedTotal = NumberFormat.getCurrencyInstance().format(totalBill)
+
+        // Show both tip and total bill
         binding.tipResult.text = getString(R.string.tip_amount, formattedTip)
+        binding.totalResult.text = getString(R.string.total_amount, formattedTotal)
     }
 
     /**

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -109,6 +109,7 @@
                 android:text="Excellent (20%)" />
         </RadioGroup>
 
+
         <ImageView
             android:id="@+id/icon_round_up"
             android:layout_width="wrap_content"
@@ -129,6 +130,16 @@
             app:layout_constraintStart_toStartOf="@id/tip_options"
             app:layout_constraintTop_toBottomOf="@id/tip_options" />
 
+        <com.google.android.material.switchmaterial.SwitchMaterial
+            android:id="@+id/round_total_switch"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/round_total_bill"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@id/tip_options"
+            app:layout_constraintTop_toBottomOf="@id/round_up_switch" />
+
+
         <Button
             android:id="@+id/calculate_button"
             android:layout_width="0dp"
@@ -148,5 +159,16 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/calculate_button"
             tools:text="Tip Amount: $10" />
+
+        <TextView
+            android:id="@+id/total_result"
+            style="@style/Widget.TipTime.TextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tip_result"
+            tools:text="Total Amount: $55" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -79,29 +79,34 @@
             android:id="@+id/tip_options"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:checkedButton="@id/option_twenty_percent"
+            android:checkedButton="@id/option_excellent_service"
             android:orientation="vertical"
             app:layout_constraintStart_toStartOf="@id/service_question"
             app:layout_constraintTop_toBottomOf="@id/service_question">
 
             <RadioButton
-                android:id="@+id/option_twenty_percent"
+                android:id="@+id/option_poor_service"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/amazing_service" />
+                android:text="Poor (10%)" />
 
             <RadioButton
-                android:id="@+id/option_eighteen_percent"
+                android:id="@+id/option_average_service"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/good_service" />
+                android:text="Average (15%)" />
 
             <RadioButton
-                android:id="@+id/option_fifteen_percent"
+                android:id="@+id/option_good_service"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/ok_service" />
+                android:text="Good (18%)" />
 
+            <RadioButton
+                android:id="@+id/option_excellent_service"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Excellent (20%)" />
         </RadioGroup>
 
         <ImageView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,9 +37,13 @@
     <!-- Text label for toggle switch that asks the user if they want to round up the tip  -->
     <string name="round_up_tip">Round up tip?</string>
 
+    <string name="round_total_bill">Round Total Bill</string>
+
     <!-- Label for button that calculates the tip  -->
     <string name="calculate">Calculate</string>
 
     <!-- Formatted string for the tip result  -->
     <string name="tip_amount">Tip Amount: %s</string>
+
+    <string name="total_amount">Total Amount: %s</string>
 </resources>


### PR DESCRIPTION
I have implemented a feature that allows users to select from predefined service rating options ("Below Average," "Satisfactory," "Great," "Outstanding") instead of manually inputting the tip percentage. Each rating now corresponds to a predefined tip percentage, streamlining the tipping process and making it more intuitive and faster for users.